### PR TITLE
config: Remove flag check for Lawnchair

### DIFF
--- a/config/packages.mk
+++ b/config/packages.mk
@@ -133,10 +133,8 @@ PRODUCT_PACKAGES += \
 PRODUCT_DEXPREOPT_SPEED_APPS += \
     Launcher3QuickStep
 else
-ifneq ($(TARGET_INCLUDE_LAWNCHAIR), true)
 PRODUCT_COPY_FILES += \
    $(call inherit-product-if-exists, vendor/extra/product.mk)
-endif
 endif
 endif
 


### PR DESCRIPTION
Each time - regardless of the flags set in the device tree - the build was compiled with the Lawnchair apps, so the flag has been moved to vendor/extra/product.mk.